### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ In the `<div class="product-list">` container you'll find a list of product item
 * Once that's done then you should enter your product name/price/thumbnail (40x40 works best).
 
 
-#####Turn.js:
+##### Turn.js:
 * Details on turn.js 4th edition and license information is available at [http://www.turnjs.com/get](http://www.turnjs.com/get) 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
